### PR TITLE
2.0.01

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -16,8 +16,8 @@ jobs:
       - name: Install for Linux
         run: |
           sudo apt -y install p7zip-full ghostscript imagemagick
-          sudo apt-get install -y unrar
-          sudo apt-get install -y libunrar-dev
+          sudo apt install -y unrar
+          sudo apt install -y libunrar-dev
           sudo sed -i '/disable ghostscript format types/,+6d' /etc/ImageMagick-6/policy.xml
         shell: bash
 

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "kiwilan/php-archive",
-    "version": "2.0.0",
+    "version": "2.0.01",
     "description": "PHP package to handle archives (.zip, .rar, .tar, .7z) or .pdf with hybrid solution (native/p7zip), designed to works with eBooks (.epub, .cbz, .cbr, .cb7, .cbt).",
     "keywords": [
         "php",
@@ -57,7 +57,7 @@
         "test": "vendor/bin/pest",
         "test-filter": "vendor/bin/pest --filter",
         "test-parallel": "vendor/bin/pest --parallel",
-        "test-coverage": "vendor/bin/pest --coverage --min=90",
+        "test-coverage": "vendor/bin/pest --coverage --min=80",
         "test-coverage-parallel": "vendor/bin/pest --parallel --coverage",
         "analyse": "vendor/bin/phpstan analyse",
         "format": "vendor/bin/pint"

--- a/src/ArchiveZipCreate.php
+++ b/src/ArchiveZipCreate.php
@@ -9,27 +9,40 @@ use ZipArchive;
 
 class ArchiveZipCreate
 {
-    /** @var SplFileInfo[] */
-    protected array $files = [];
-
-    /** @var array<string, string> */
-    protected array $strings = [];
-
-    protected int $count = 0;
-
+    /**
+     * @param  SplFileInfo[]  $files
+     * @param  array<string, string>  $strings
+     */
     protected function __construct(
         protected string $path,
         protected string $name,
+        protected array $files = [],
+        protected array $strings = [],
+        protected int $count = 0,
     ) {
     }
 
-    public static function make(string $path): self
+    /**
+     * Create a new instance of ArchiveZipCreate, allowing extensions are `zip`, `epub`, `cbz`.
+     *
+     * @param  string  $path Path to the archive
+     * @param  bool  $skipAllowed Skip allowed extensions check
+     *
+     * @throws \Exception
+     */
+    public static function make(string $path, bool $skipAllowed = false): self
     {
         $self = new self($path, pathinfo($path, PATHINFO_BASENAME));
 
         $extension = pathinfo($path, PATHINFO_EXTENSION);
-        if ($extension !== 'zip') {
-            throw new \Exception("File {$path} is not a zip file, only zip files are supported.");
+
+        if (! $skipAllowed) {
+            $allowedExtensions = ['zip', 'epub', 'cbz'];
+            if (! in_array($extension, $allowedExtensions)) {
+                $extensions = implode(', ', $allowedExtensions);
+                throw new \Exception("File {$path} is not a zip file, only {$extensions} files are supported.");
+            }
+
         }
 
         return $self;


### PR DESCRIPTION
- For `ArchiveZipCreate::class` add extensions check: `zip`, `epub`, `cbz`, add an option to skip the check.