### PR TITLE
2.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,13 +148,17 @@ Works only with `.zip` archives.
 
 ```php
 $archive = Archive::make('path/to/archive.zip');
-$archive->addFiles([
-    'path/to/file1.txt',
-    'path/to/file2.txt',
-    'path/to/file3.txt',
-]);
+$files = [
+    'path/to/file/in/archive-file1.txt' => 'path/to/real-file1.txt',
+    'path/to/file/in/archive-file2.txt' => 'path/to/real-file2.txt',
+    'path/to/file/in/archive-file3.txt' => 'path/to/real-file3.txt',
+];
+
+foreach ($files as $pathInArchive => $pathToRealFile) {
+    $archive->addFile($pathInArchive, $pathToRealFile);
+}
 $archive->addFromString('test.txt', 'Hello World!');
-$archive->addDirectory('path/to/directory');
+$archive->addDirectory('./directory', 'path/to/directory');
 $archive->save();
 ```
 

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "kiwilan/php-archive",
-    "version": "2.0.02",
+    "version": "2.1.0",
     "description": "PHP package to handle archives (.zip, .rar, .tar, .7z) or .pdf with hybrid solution (native/p7zip), designed to works with eBooks (.epub, .cbz, .cbr, .cb7, .cbt).",
     "keywords": [
         "php",

--- a/tests/ArchiveCreateTest.php
+++ b/tests/ArchiveCreateTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use Kiwilan\Archive\Archive;
+use Kiwilan\Archive\ArchiveFile;
 
 beforeEach(function () {
     recurseRmdir(outputPath());
@@ -9,14 +10,16 @@ beforeEach(function () {
 it('can create', function () {
     $path = outputPath(filename: 'test.zip');
     $medias = [
-        mediaPath('archive/cover.jpeg'),
-        mediaPath('archive/file-1.md'),
-        mediaPath('archive/file-2.md'),
-        mediaPath('archive/file-3.md'),
-        mediaPath('archive/metadata.xml'),
+        'archive/cover.jpeg' => mediaPath('archive/cover.jpeg'),
+        'archive/file-1.md' => mediaPath('archive/file-1.md'),
+        'archive/file-2.md' => mediaPath('archive/file-2.md'),
+        'archive/file-3.md' => mediaPath('archive/file-3.md'),
+        'archive/metadata.xml' => mediaPath('archive/metadata.xml'),
     ];
     $archive = Archive::make($path);
-    $archive->addFiles($medias);
+    foreach ($medias as $output => $media) {
+        $archive->addFile($output, $media);
+    }
     $archive->save();
 
     expect($archive->getPath())->toBe($path);
@@ -24,20 +27,23 @@ it('can create', function () {
     expect($archive->getPath())->toBeReadableFile($path);
     expect($archive->getCount())->toBe(5);
     expect($archive->getFiles())->toBeArray()
-        ->each(fn ($file) => expect($file->value)->toBeInstanceOf(SplFileInfo::class));
+        ->each(fn ($file) => expect($file->value)->toBeInstanceOf(ArchiveFile::class));
 });
 
 it('can create with files', function () {
     $path = outputPath(filename: 'test.zip');
+    $files = [
+        'archive/cover.jpeg' => mediaPath('archive/cover.jpeg'),
+        'archive/file-1.md' => mediaPath('archive/file-1.md'),
+        'archive/file-2.md' => mediaPath('archive/file-2.md'),
+        'archive/file-3.md' => mediaPath('archive/file-3.md'),
+        'archive/metadata.xml' => mediaPath('archive/metadata.xml'),
+    ];
 
     $archive = Archive::make($path);
-    $archive->addFiles([
-        mediaPath('archive/cover.jpeg'),
-        mediaPath('archive/file-1.md'),
-        mediaPath('archive/file-2.md'),
-        mediaPath('archive/file-3.md'),
-        mediaPath('archive/metadata.xml'),
-    ]);
+    foreach ($files as $path => $file) {
+        $archive->addFile($path, $file);
+    }
     $archive->addFromString('test.txt', 'Hello World!');
     $archive->save();
 
@@ -61,18 +67,19 @@ it('can create with directory', function () {
     $path = outputPath(filename: 'test.zip');
 
     $archive = Archive::make($path);
-    $archive->addDirectory(mediaPath('archive'));
+    $archive->addDirectory('./archive', mediaPath('archive'));
+    $archive->addFromString('test.txt', 'Hello World!');
     $archive->save();
 
     expect($archive->getPath())->toBeReadableFile($path);
-    expect($archive->getCount())->toBe(5);
+    expect($archive->getCount())->toBe(6);
 });
 
 it('can edit', function () {
     $path = outputPath(filename: 'test.zip');
 
     $archive = Archive::make($path);
-    $archive->addDirectory(mediaPath('archive'));
+    $archive->addDirectory('./archive', mediaPath('archive'));
     $archive->save();
 
     $archive = Archive::make($path);


### PR DESCRIPTION
Rework `Archive::make()`

- `addFile()` takes two parameters now: the `outputPath` inside archive and `pathToFile` on disk
- ~~`addFiles()`~~ is removed
- `addDirectory()` takes two parameters now: `relativeTo` path inside archive and the `path` of directory on the disk
  - If the `path` is `/path/to/dir` and `relativeTo` is `./dir`, the directory will be added to archive as `dir/`
- ~~`addDirectories()`~~ is removed