### PR TITLE
v2.1.02

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,26 +53,26 @@ If you want more information, you can read section [**About**](#about).
 ## Features
 
 -   List files as `ArchiveItem` array
-    -   With `getFiles` method: list of files
-    -   With `getFirst` method: first file
-    -   With `getLast` method: last file
-    -   With `find` method: find first file that match with `path` property
-    -   With `filter` method: find all files that match with `path` property
+    -   With `getFiles()` method: list of files
+    -   With `getFirst()` method: first file
+    -   With `getLast()` method: last file
+    -   With `find()` method: find first file that match with `path` property
+    -   With `filter()` method: find all files that match with `path` property
 -   Content of file
-    -   With `getContent` method: content of file as string (useful for images)
-    -   With `getText` method: content of text file (binaries files return `null`)
+    -   With `getContents()` method: content of file as string (useful for images)
+    -   With `getText()` method: content of text file (binaries files return `null`)
 -   Extract files
-    -   With `extract` method: extract files to directory
-    -   With `extractAll` method: extract all files to directory
--   Stat of archive with `getPath`, `getDeviceNumber`, `getInodeNumber`, `getInodeProtectionMode`, `getNumberOfLinks`, `getUserId`, `getGroupId`, `getDeviceType`, `getSize`, `getLastAccessAt`, `getCreatedAt`, `getModifiedAt`, `getBlockSize`, `getNumberOfBlocks`, `getStatus`, `getComment` properties
--   PDF metadata: `getTitle`, `getAuthor`, `getSubject`, `getCreator`, `getCreationDate`, `getModDate`, `getPages`,
+    -   With `extract()` method: extract files to directory
+    -   With `extractAll()` method: extract all files to directory
+-   Stat of archive corresponding to [`stat`](https://www.php.net/manual/en/function.stat.php)
+-   PDF metadata: `getTitle()`, `getAuthor()`, `getSubject()`, `getCreator()`, `getCreationDate()`, `getModDate()`, `getPages()`,
 -   Count files
 -   Create or edit archives, only with `.zip` format
-    -   With `make` method: create or edit archive
-    -   With `addFiles` method: add files to archive
-    -   With `addFromString` method: add string to archive
-    -   With `addDirectory` and `addDirectories` methods: add directories to archive
-    -   With `save` method: save archive
+    -   With `make()` method: create or edit archive
+    -   With `addFiles()` method: add files to archive
+    -   With `addFromString()` method: add string to archive
+    -   With `addDirectory()` and `addDirectories()` methods: add directories to archive
+    -   With `save()` method: save archive
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ $count = $archive->getCount(); // int of files count
 
 $images = $archive->filter('jpeg'); // ArchiveItem[] with `jpeg` in their path
 $metadataXml = $archive->find('metadata.xml'); // First ArchiveItem with `metadata.xml` in their path
-$content = $archive->getContent($metadataXml); // `metadata.xml` file content
+$content = $archive->getContents($metadataXml); // `metadata.xml` file content
 
 $paths = $archive->extract('/path/to/directory', [$metadataXml]); // string[] of extracted files paths
 $paths = $archive->extractAll('/path/to/directory'); // string[] of extracted files paths
@@ -109,7 +109,7 @@ $archive = Archive::read('path/to/file.pdf');
 
 $pdf = $archive->getPdf(); // Metadata of PDF
 
-$content = $archive->getContent($archive->getFirst()); // PDF page as image
+$content = $archive->getContents($archive->getFirst()); // PDF page as image
 $text = $archive->getText($archive->getFirst()); // PDF page as text
 ```
 

--- a/README.md
+++ b/README.md
@@ -27,13 +27,13 @@ Supports Linux, macOS and Windows.
     -   [`imagick`](https://www.php.net/manual/en/book.imagick.php) (optional) for `.PDF`
     -   [`bz2`](https://www.php.net/manual/en/book.bzip2.php) (optional) for `.BZ2` archives
 
-|           Type            | Supported |                                               Requirement                                                |         Uses         |
-| :-----------------------: | :-------: | :------------------------------------------------------------------------------------------------------: | :------------------: |
-|  `.zip`, `.epub`, `.cbz`  |    ✅     |                                                   N/A                                                    |         N/A          |
-| `.tar`, `.tar.gz`, `.cbt` |    ✅     |                                                   N/A                                                    |         N/A          |
-|      `.rar`, `.cbr`       |    ✅     | [`rar` PHP extension](https://github.com/cataphract/php-rar) or [`p7zip`](https://www.7-zip.org/) binary | PHP `rar` or `p7zip` |
-|       `.7z`, `.cb7`       |    ✅     |                                 [`p7zip`](https://www.7-zip.org/) binary                                 |    `p7zip` binary    |
-|          `.pdf`           |    ✅     |         Optional (for extraction) [`imagick` PHP extension](https://github.com/Imagick/imagick)          |  `smalot/pdfparser`  |
+|           Type            | Supported |                                               Requirement                                                |                                 Uses                                 |
+| :-----------------------: | :-------: | :------------------------------------------------------------------------------------------------------: | :------------------------------------------------------------------: |
+|  `.zip`, `.epub`, `.cbz`  |    ✅     |                                                   N/A                                                    |  Uses [`zip` extension](https://www.php.net/manual/en/book.zip.php)  |
+| `.tar`, `.tar.gz`, `.cbt` |    ✅     |                                                   N/A                                                    | Uses [`phar` extension](https://www.php.net/manual/en/book.phar.php) |
+|      `.rar`, `.cbr`       |    ✅     | [`rar` PHP extension](https://github.com/cataphract/php-rar) or [`p7zip`](https://www.7-zip.org/) binary |                         PHP `rar` or `p7zip`                         |
+|       `.7z`, `.cb7`       |    ✅     |                                 [`p7zip`](https://www.7-zip.org/) binary                                 |                            `p7zip` binary                            |
+|          `.pdf`           |    ✅     |         Optional (for extraction) [`imagick` PHP extension](https://github.com/Imagick/imagick)          |                          `smalot/pdfparser`                          |
 
 > **Note**
 >

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "kiwilan/php-archive",
-    "version": "2.1.01",
+    "version": "2.1.02",
     "description": "PHP package to handle archives (.zip, .rar, .tar, .7z) or .pdf with hybrid solution (native/p7zip), designed to works with eBooks (.epub, .cbz, .cbr, .cb7, .cbt).",
     "keywords": [
         "php",

--- a/src/Readers/ArchivePdf.php
+++ b/src/Readers/ArchivePdf.php
@@ -32,7 +32,7 @@ class ArchivePdf extends BaseArchive
         $paths = [];
         foreach ($this->files as $file) {
             if (in_array($file, $files)) {
-                $content = $this->getContent($file);
+                $content = $this->getContents($file);
                 $toPathFile = "{$toPath}{$file->getPath()}.{$this->pdfExt}";
 
                 if (! is_dir(dirname($toPathFile))) {
@@ -47,7 +47,15 @@ class ArchivePdf extends BaseArchive
         return $paths;
     }
 
+    /**
+     * @deprecated Use `getContents()` instead
+     */
     public function getContent(?ArchiveItem $file, bool $toBase64 = false): ?string
+    {
+        return $this->getContents($file, $toBase64);
+    }
+
+    public function getContents(?ArchiveItem $file, bool $toBase64 = false): ?string
     {
         if (! $file) {
             return null;

--- a/src/Readers/ArchivePhar.php
+++ b/src/Readers/ArchivePhar.php
@@ -18,7 +18,15 @@ class ArchivePhar extends BaseArchive
         return $self;
     }
 
+    /**
+     * @deprecated Use `getContents()` instead
+     */
     public function getContent(?ArchiveItem $file, bool $toBase64 = false): ?string
+    {
+        return $this->getContents($file, $toBase64);
+    }
+
+    public function getContents(?ArchiveItem $file, bool $toBase64 = false): ?string
     {
         if (! $file) {
             return null;
@@ -35,14 +43,14 @@ class ArchivePhar extends BaseArchive
             throw new \Exception("Error, {$file->getFilename()} is an image");
         }
 
-        return $this->getContent($file);
+        return $this->getContents($file);
     }
 
     public function extract(string $toPath, array $files): array
     {
         $paths = [];
         foreach ($files as $file) {
-            $content = $this->getContent($file);
+            $content = $this->getContents($file);
 
             $toPathFile = "{$toPath}{$file->getRootPath()}";
 

--- a/src/Readers/ArchiveRar.php
+++ b/src/Readers/ArchiveRar.php
@@ -53,7 +53,15 @@ class ArchiveRar extends BaseArchive
         return $paths;
     }
 
+    /**
+     * @deprecated Use `getContents()` instead
+     */
     public function getContent(?ArchiveItem $item, bool $toBase64 = false): ?string
+    {
+        return $this->getContents($item, $toBase64);
+    }
+
+    public function getContents(?ArchiveItem $item, bool $toBase64 = false): ?string
     {
         if (! $item) {
             return null;

--- a/src/Readers/ArchiveSevenZip.php
+++ b/src/Readers/ArchiveSevenZip.php
@@ -17,7 +17,15 @@ class ArchiveSevenZip extends BaseArchive
         return $self;
     }
 
+    /**
+     * @deprecated Use `getContents()` instead
+     */
     public function getContent(?ArchiveItem $file, bool $toBase64 = false): ?string
+    {
+        return $this->getContents($file, $toBase64);
+    }
+
+    public function getContents(?ArchiveItem $file, bool $toBase64 = false): ?string
     {
         if (! $file) {
             return null;

--- a/src/Readers/ArchiveZip.php
+++ b/src/Readers/ArchiveZip.php
@@ -51,7 +51,15 @@ class ArchiveZip extends BaseArchive
         return $files;
     }
 
+    /**
+     * @deprecated Use `getContents()` instead
+     */
     public function getContent(?ArchiveItem $file, bool $toBase64 = false): ?string
+    {
+        return $this->getContents($file, $toBase64);
+    }
+
+    public function getContents(?ArchiveItem $file, bool $toBase64 = false): ?string
     {
         if (! $file) {
             return null;

--- a/src/Readers/BaseArchive.php
+++ b/src/Readers/BaseArchive.php
@@ -171,8 +171,15 @@ abstract class BaseArchive
 
     /**
      * Get content from file.
+     *
+     * @deprecated Use `getContents()` instead
      */
     abstract public function getContent(?ArchiveItem $file, bool $toBase64 = false): ?string;
+
+    /**
+     * Get content from file.
+     */
+    abstract public function getContents(?ArchiveItem $file, bool $toBase64 = false): ?string;
 
     /**
      * Get text from file.

--- a/tests/ArchiveTest.php
+++ b/tests/ArchiveTest.php
@@ -70,7 +70,7 @@ it('can find all images', function (string $path) {
 
 it('can get content first file', function (string $path) {
     $archive = Archive::read($path);
-    $content = $archive->getContent($archive->getFirst());
+    $content = $archive->getContents($archive->getFirst());
 
     $output = outputPath();
     $file = BaseArchive::pathToOsPath("{$output}first.jpg");
@@ -78,12 +78,14 @@ it('can get content first file', function (string $path) {
 
     expect($content)->toBeString();
     expect($file)->toBeReadableFile();
+
+    $content = $archive->getContent($archive->getFirst());
 })->with([...ARCHIVES_ZIP, ...ARCHIVES_TAR, ...ARCHIVES_RAR, SEVENZIP]);
 
 it('can get cover', function (string $path) {
     $archive = Archive::read($path);
     $cover = $archive->find('cover.jpeg');
-    $content = $archive->getContent($cover);
+    $content = $archive->getContents($cover);
 
     $output = outputPath();
     $coverPath = "{$output}cover.jpeg";

--- a/tests/PdfTest.php
+++ b/tests/PdfTest.php
@@ -18,7 +18,7 @@ it('can get files', function () {
 
 it('can get content first file', function () {
     $archive = Archive::read(PDF);
-    $content = $archive->getContent($archive->getFirst());
+    $content = $archive->getContents($archive->getFirst());
 
     $output = outputPath();
     $file = "{$output}first.jpg";


### PR DESCRIPTION
- All `getContent()` methods are now `getContents()`
- Old `getContent()` methods are deprecated and will be removed in v3.0.0