### PR TITLE
v2.3.0

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+SEVEN_ZIP_BINARY_PATH_LINUX=/usr/bin/7z
+SEVEN_ZIP_BINARY_PATH_WINDOWS=C:\Users\runneradmin\scoop\apps\7zip\current\7z.exe
+SEVEN_ZIP_BINARY_PATH_MACOS=/usr/local/bin/7z

--- a/.github/workflows/run-macos.yml
+++ b/.github/workflows/run-macos.yml
@@ -19,6 +19,11 @@ jobs:
           brew install rar
           brew install ghostscript
           brew install imagemagick
+        shell: bash
+
+      - name: Check 7z path
+        continue-on-error: true
+        run: |
           which 7z
         shell: bash
 

--- a/.github/workflows/run-macos.yml
+++ b/.github/workflows/run-macos.yml
@@ -55,6 +55,11 @@ jobs:
           sudo cp ./modules/rar.so $pecl_path
           sudo echo "extension=rar.so" > $phpini_path
 
+      - name: Create .env file
+        run: |
+          cp .env.example .env
+        shell: bash
+
       - name: Check extension rar
         run: php -m | grep rar
 

--- a/.github/workflows/run-macos.yml
+++ b/.github/workflows/run-macos.yml
@@ -21,12 +21,6 @@ jobs:
           brew install imagemagick
         shell: bash
 
-      - name: Check 7z path
-        continue-on-error: true
-        run: |
-          which 7z
-        shell: bash
-
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:

--- a/.github/workflows/run-macos.yml
+++ b/.github/workflows/run-macos.yml
@@ -19,6 +19,7 @@ jobs:
           brew install rar
           brew install ghostscript
           brew install imagemagick
+          which 7z
         shell: bash
 
       - name: Setup PHP

--- a/.github/workflows/run-tests-pz7ip.yml
+++ b/.github/workflows/run-tests-pz7ip.yml
@@ -31,6 +31,11 @@ jobs:
       - name: Install dependencies
         run: composer update --prefer-dist --no-interaction
 
+      - name: Create .env file
+        run: |
+          cp .env.example .env
+        shell: bash
+
       - name: Check extension imagick
         run: php -m | grep imagick
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -55,6 +55,11 @@ jobs:
           sudo cp ./modules/rar.so $pecl_path
           sudo echo "extension=rar.so" > $phpini_path
 
+      - name: Create .env file
+        run: |
+          cp .env.example .env
+        shell: bash
+
       - name: Check extension rar
         run: php -m | grep rar
 

--- a/.github/workflows/run-windows.yml
+++ b/.github/workflows/run-windows.yml
@@ -47,6 +47,11 @@ jobs:
       - name: Install dependencies
         run: composer update --prefer-dist --no-interaction
 
+      - name: Create .env file
+        run: |
+          cp .env.example .env
+        shell: powershell
+
       # - name: Check extension rar
       #   run: php -m | grep rar
 

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ example
 temp
 CHANGELOG-draft.md
 .phpunit.cache
+.env

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 [![tests][tests-src]][tests-href]
 [![codecov][codecov-src]][codecov-href]
 
-PHP package to handle archives (`.zip`, `.rar`, `.tar`, `.7z`, `.pdf`) with unified API and hybrid solution (native/`p7zip`), designed to works with eBooks (`.epub`, `.cbz`, `.cbr`, `.cb7`, `.cbt`).
+PHP package to handle archives (`.zip`, `.rar`, `.tar`, `.7z`, `.pdf`) with unified API and hybrid solution (native/`p7zip`), designed to works with EPUB and CBA (`.cbz`, `.cbr`, `.cb7`, `.cbt`).
 
 Supports Linux, macOS and Windows.
 

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "kiwilan/php-archive",
-    "version": "2.2.0",
+    "version": "2.3.0",
     "description": "PHP package to handle archives (.zip, .rar, .tar, .7z, .pdf) with unified API and hybrid solution (native/p7zip), designed to works with EPUB and CBA (.cbz, .cbr, .cb7, .cbt).",
     "keywords": [
         "php",

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "kiwilan/php-archive",
     "version": "2.2.0",
-    "description": "PHP package to handle archives (.zip, .rar, .tar, .7z, .pdf) with unified API and hybrid solution (native/p7zip), designed to works with eBooks (.epub, .cbz, .cbr, .cb7, .cbt).",
+    "description": "PHP package to handle archives (.zip, .rar, .tar, .7z, .pdf) with unified API and hybrid solution (native/p7zip), designed to works with EPUB and CBA (.cbz, .cbr, .cb7, .cbt).",
     "keywords": [
         "php",
         "archive",

--- a/tests/ArchiveTest.php
+++ b/tests/ArchiveTest.php
@@ -159,14 +159,7 @@ it('can handle archive with password', function (string $path) {
 })->with([ZIP_PASSWORD, RAR_PASSWORD, SEVENZIP_PASSWORD, TAR_PASSWORD]);
 
 it('can handle archive with binary path', function (string $path) {
-    if (PHP_OS_FAMILY === 'Windows') {
-        $current_user = exec('echo %USERNAME%');
-        $binary_path = "C:\\Users\\{$current_user}\\scoop\\apps\\7zip\\current\\7z.exe";
-    } elseif (PHP_OS_FAMILY === 'Darwin') {
-        $binary_path = '/opt/homebrew/bin/7z';
-    } else {
-        $binary_path = '/usr/bin/7z';
-    }
+    $binary_path = getSevenZipBinaryPath();
     $archive = Archive::read($path)->overrideBinaryPath($binary_path);
 
     $files = $archive->getFileItems();

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -179,3 +179,53 @@ function recurseRmdir(string $dir)
     }
     // rmdir($dir);
 }
+
+function dotenv(): array
+{
+    $path = __DIR__.'/../';
+    $lines = file($path.'.env');
+    $dotenv = [];
+
+    foreach ($lines as $line) {
+        if (! empty($line)) {
+            $data = explode('=', $line);
+            $key = $data[0];
+            if ($key === " \n ") {
+                continue;
+            }
+            unset($data[0]);
+            $value = implode('=', $data);
+
+            $key = $key ? trim($key) : '';
+            $value = $value ? trim($value) : '';
+
+            if ($key === '') {
+                continue;
+            }
+
+            $value = str_replace('"', '', $value);
+            $value = str_replace("'", '', $value);
+
+            $dotenv[$key] = $value;
+        }
+    }
+
+    return $dotenv;
+}
+
+function getDotenv(string $key): string
+{
+    return dotenv()[$key] ?? '';
+}
+
+function getSevenZipBinaryPath(): string
+{
+    $os = PHP_OS_FAMILY;
+    $dotenv = match ($os) {
+        'Windows' => 'SEVEN_ZIP_BINARY_PATH_WINDOWS',
+        'Darwin' => 'SEVEN_ZIP_BINARY_PATH_MACOS',
+        default => 'SEVEN_ZIP_BINARY_PATH_LINUX',
+    };
+
+    return getDotenv($dotenv);
+}


### PR DESCRIPTION
- Add password option for ZIP, RAR and 7z files, using `read(string $path, ?string $password = null)` and `readFromString(string $contents, ?string $password = null, ?string $extension = null)` methods.
- Add new `Archive::class` method `readFromString(string $contents, ?string $password = null, ?string $extension = null)` to read an archive from a string
- When you read RAR or 7z archives with `p7zip` binary, you can set manually the path to the binary using `overrideBinaryPath(string $path)` method.
- `getFiles()` method is now deprecated. Use `getFileItems()` instead.
- New method `getFileItem(string $path)` to get a single file item.
