### PR TITLE
Various bugfixes due to humans being humans

### DIFF
--- a/src/Archive.php
+++ b/src/Archive.php
@@ -65,6 +65,8 @@ class Archive
                     throw $originalException;
                 }
             }
+
+            throw $originalException;
         }
     }
 

--- a/src/Processes/SevenZipProcess.php
+++ b/src/Processes/SevenZipProcess.php
@@ -67,6 +67,28 @@ class SevenZipProcess
     }
 
     /**
+     * Escapes a string to be used as a shell argument.
+     */
+    private function escapeArgument(?string $argument): string
+    {
+        if ('' === $argument || null === $argument) {
+            return '""';
+        }
+        if ('\\' !== \DIRECTORY_SEPARATOR) {
+            return "'".str_replace("'", "'\\''", $argument)."'";
+        }
+        if (str_contains($argument, "\0")) {
+            $argument = str_replace("\0", '?', $argument);
+        }
+        if (!preg_match('/[()%!^"<>&|\s]/', $argument)) {
+            return $argument;
+        }
+        $argument = preg_replace('/(\\\\+)$/', '$1$1', $argument);
+
+        return '"'.str_replace(['"', '^', '%', '!', "\n"], ['""', '"^^"', '"^%"', '"^!"', '!LF!'], $argument).'"';
+    }
+
+    /**
      * @param  string[]  $args
      * @return string[]
      */
@@ -82,7 +104,7 @@ class SevenZipProcess
             $command = $this->binaryPath;
         }
 
-        $command = "{$command} ".implode(' ', $args);
+        $command = "{$command} ".implode(' ', array_map($this->escapeArgument(...), $args));
 
         try {
             exec($command, $output, $res);

--- a/src/Readers/ArchivePdf.php
+++ b/src/Readers/ArchivePdf.php
@@ -84,8 +84,7 @@ class ArchivePdf extends BaseArchive
             $imagick->clear();
             $imagick->destroy();
         } catch (\Throwable $th) {
-            // throw new \Exception("Error, {$file->getFilename()} is not an image");
-            error_log("Error, {$file->getFilename()} is not an image");
+            error_log("Error, {$file->getFilename()} Failed to extract page: {$th->getMessage()}");
         }
 
         if (! $content) {


### PR DESCRIPTION
Hi,

I'm contributing these fixes to this library as it is used in the https://github.com/biblioverse/biblioteca project, more specifically to scan ebooks.

I've encountered three errors with this library and decided to make a single Pull Request for all three, please tell me if you'd rather have separate pull requests.

## 1. Missing escaping of CLI arguments

When calling 7zip, it happens that the file called contains a space, a `-` or a quote. These characters are directly interpreted in the terminal and cause the library to behave improperly.

I added escaping of arguments to avoid this issue.

Note that the method used comes from Symfony; https://github.com/symfony/process/blob/7.2/Process.php#L1637 I don't know what the proper process of attribution is for this kind of copy.

## 2. Errors swallowed hiding the original error

When extracting a page from a PDF, if it fails only a `Error, page_0 is not an image` message is displayed.

The actual error was `cache resources exhausted `/tmp/magick-MEUnRhIPjodKoNbmiZiE_XiYy0Tn9dQV1' @ error/cache.c/OpenPixelCache/4095` and this message helped me figure out a fix.

This second change makes the original error message visible.

## 3. Sometimes a .cbz is a RAR file, sometimes a .cbr is a ZIP file

I'm open to discuss this one as it could be controversial.
I have many comic books and it happens that the person who created them didn't know that .cbZ = ZIP and .cbR = RAR.
The result is that sometimes a `.cbz` is a RAR file or a `.cbr` is a ZIP file

The change I propose is to check failed parsings of a `.cbr/.cbz` as the opposite format.

If you prefer, I could propose an alternative which would be to test-parse the file and provide an helpful message such as "This file has a .cbz extension and should be a ZIP archive but is actually a RAR archive, please rename this file to .cbr"

> note for me: This partially fixes https://github.com/biblioverse/biblioteca/issues/317