### PR TITLE
v2.3.02

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "kiwilan/php-archive",
-    "version": "2.3.01",
+    "version": "2.3.02",
     "description": "PHP package to handle archives (.zip, .rar, .tar, .7z, .pdf) with unified API and hybrid solution (native/p7zip), designed to works with EPUB and CBA (.cbz, .cbr, .cb7, .cbt).",
     "keywords": [
         "php",

--- a/src/ArchiveTemporaryDirectory.php
+++ b/src/ArchiveTemporaryDirectory.php
@@ -14,7 +14,12 @@ class ArchiveTemporaryDirectory
 
     public static function make(?string $filename = null): self
     {
-        return new self(uniqid(), $filename);
+        $prefix = substr(bin2hex(random_bytes(2)), 0, 4);
+        $uniq = uniqid(more_entropy: true);
+        $uniq = str_replace('.', '', $uniq);
+        $uuid = "archive_{$prefix}_{$uniq}";
+
+        return new self($uuid, $filename);
     }
 
     public function clear(): bool


### PR DESCRIPTION
For `ArchiveTemporaryDirectory` temporary directory name is now based on a UUID format: `archive_{prefix}_{uniq}` where `prefix` is a random 4-character string and `uniq` is a unique identifier generated using `uniqid()`.
